### PR TITLE
Add peerjs backend prototype

### DIFF
--- a/peerjs-backend/README.md
+++ b/peerjs-backend/README.md
@@ -1,0 +1,53 @@
+To use the file `index.html`, open it in two browser tabs, register with different usernames and then you can send messages by typing the id of the receiver and the message 
+and clicking Send.
+
+
+There are several options for the backend communication. The simplest thing is to use the public server without a STUN/TURN server. To use this option, use the following line
+for the initialization of the Peer object:
+
+```
+peer = new Peer(username)
+```
+
+The best option is to host your own peerJS and TURN servers. 
+
+To host the peerJS server, you need to do the following steps:
+
+1. Follow steps 1-4 in this [tutorial](https://ourcodeworld.com/articles/read/977/how-to-deploy-a-node-js-application-on-aws-ec2-server) 
+to create an EC2 instance and install Node.js on it. 
+2. Install and run the server by following the official installation [instructions](https://github.com/peers/peerjs-server#run-server)
+3. Open port 9000 on the EC2 instance. To open a port on AWS, follow the instruction from point 6 in this [tutorial](https://ourcodeworld.com/articles/read/977/how-to-deploy-a-node-js-application-on-aws-ec2-server)
+4. Replace `<aws-instance-public-ip>` in the code with the public IP address of your EC2 instance.  
+
+To host your own TURN server, you can follow the same procedure from point 1 to create and ssh into your EC2 instance. After you ssh into the EC2 instance, you need to install
+coturn using the following commands:
+
+```
+$ sudo apt-get update
+$ sudo apt-get install coturn
+```
+
+Then, you need to open the following ports on the AWS instance:
+
+```
+80 : TCP 
+443 : TCP 
+3478 : UDP
+3478 : TCP
+10000–20000 : UDP
+```
+
+For instructions on how to do this, see point 3 in the instructions for running the peerJS server above. 
+
+To run the TURN server, use the following command:
+
+```
+turnserver -a -v -n -u <username>:<password> -p 3478 -r myRealm -X <aws-instance-public-ip> --no-dtls --no-tls
+```
+
+Don't forget to replace `<username>`, `<password>` and `<aws-instance-public-ip>` with appropriate values. You should now be able to use the TURN server. 
+
+By default, the code uses both a personal peerjs server and turn server. Please update the username, password and public IP address in the appropriate places in the code. 
+
+To disable the usage of a turn server, you can remove the `config` property from the intitialization of the `Peer` object. 
+

--- a/peerjs-backend/index.html
+++ b/peerjs-backend/index.html
@@ -1,0 +1,45 @@
+<html>
+  <body>
+<div>
+<input type="text" placeholder="Username" id="username">
+<button onclick="register()">Register</button>
+</div>
+
+<div>
+<input type="text" placeholder="Receiver" id="receiver">
+<input type="text" placeholder="Message" id="message">
+<button onclick="send()">Send</button>
+</div>
+
+<script src="https://unpkg.com/peerjs@1.3.1/dist/peerjs.min.js"></script>
+<script>
+console.log('start')
+
+peer = null
+function register() {
+  const username = document.getElementById("username").value
+  //peer = new Peer(username, { host: 'localhost', port: 9000, path: '/myapp' })
+peer = new Peer(username)
+
+peer.on('connection', (conn) => {
+  conn.on('data', (data) => {
+    console.log(data);
+  })
+})
+}
+
+function send() {
+  const receiver = document.getElementById("receiver").value
+  const data = document.getElementById("message").value
+  const conn = peer.connect(receiver)
+
+  conn.on('open', () => {
+    conn.send(data)
+  })
+}
+
+</script>
+  </body>
+</html>
+ 
+

--- a/peerjs-backend/index.html
+++ b/peerjs-backend/index.html
@@ -18,13 +18,27 @@ console.log('start')
 peer = null
 function register() {
   const username = document.getElementById("username").value
-  //peer = new Peer(username, { host: 'localhost', port: 9000, path: '/myapp' })
-peer = new Peer(username)
+
+// Uncomment this to use the public peerjs server without turn server
+// peer = new Peer(username)
+
+// Remove config property to disable the use of a turn server
+peer = new Peer(username, 
+{
+host: '<aws-instance-public-ip>', port: 9000, path: '/myapp',
+config: {'iceServers': [
+    { url: 'stun:stun.l.google.com:19302' },
+    { url: 'turn:<aws-instance-public-ip>:3478', credential: 'deai', username: 'deai' }
+  ]} 
+}
+)
 
 peer.on('connection', (conn) => {
+  console.log('new connection')
+  conn.on('open',function(){
   conn.on('data', (data) => {
     console.log(data);
-  })
+  })})
 })
 }
 
@@ -41,5 +55,3 @@ function send() {
 </script>
   </body>
 </html>
- 
-


### PR DESCRIPTION
This is a simple example of p2p communication with [peerJS](https://github.com/peers/peerjs). The benefit of peerJS is that it is much simpler to work with than pure WebRTC and they provide a free hosted server for development. The only requirement Is to choose unique usernames so that they don't collide with others using the public server. Additionally, they provide the server code as another [library](https://github.com/peers/peerjs-server). In this way, we can host our own server without having to implement it from scratch, and also customize it to our needs. With the publically hosted server, we need a way to share the ids between users. However, if we host our own server, there is an option to get a list of all connected peers from the server which will eliminate the need to communicate the ids. 

To test the example, open the file in two tabs, choose unique usernames, register on both tabs, and then you can send messages from one to the other.

I also tested the example with a locally hosted server (the commented line in the code) and it works fine.

The next step is to try to host our own server on the cloud.

Let me know if you have any questions or suggestions. 