### PR TITLE
Model/training sharing prototype

### DIFF
--- a/peerjs-backend/index.html
+++ b/peerjs-backend/index.html
@@ -7,44 +7,91 @@
 
 <div>
 <input type="text" placeholder="Receiver" id="receiver">
-<input type="text" placeholder="Message" id="message">
 <button onclick="send()">Send</button>
 </div>
 
 <script src="https://unpkg.com/peerjs@1.3.1/dist/peerjs.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@2.0.0/dist/tf.min.js"></script>
+<script src="https://rawgit.com/kawanet/msgpack-lite/master/dist/msgpack.min.js"></script>
 <script>
 console.log('start')
 
+async function serializeTensor(tensor) {
+    return {
+        "$tensor": {
+            "data": await tensor.data(), // doesn't copy (maybe depending on runtime)!
+            "shape": tensor.shape,
+            "dtype": tensor.dtype
+        }
+    }
+}
+function deserializeTensor(dict) {
+    const {data, shape, dtype} = dict["$tensor"];
+    return tf.tensor(data, shape, dtype); // doesn't copy (maybe depending on runtime)!
+}
+async function serializeVariable(variable) {
+    return {
+        "$variable": {
+            "name": variable.name,
+            "val": await serializeTensor(variable.val),
+        }
+    }
+}
+
+async function serializeModel(model) {
+    return await Promise.all(model.weights.map(serializeVariable));
+}
+
+function assignWeightsToModel(serializedWeights, model) {
+    // This assumes the weights are in the right order
+    model.weights.forEach((weight, idx) => {
+        const serializedWeight = serializedWeights[idx]["$variable"];
+        const tensor = deserializeTensor(serializedWeight.val);
+        weight.val.assign(tensor);
+        tensor.dispose();
+    });
+}
+
 peer = null
+const model = tf.sequential();
+model.add(tf.layers.dense({units: 32, inputShape: [50]}));
+model.add(tf.layers.dense({units: 4}));
+
 function register() {
   const username = document.getElementById("username").value
 
 // Uncomment this to use the public peerjs server without turn server
-// peer = new Peer(username)
+peer = new Peer(username, {host: 'localhost', port: 9000, path: '/myapp'})
 
 // Remove config property to disable the use of a turn server
-peer = new Peer(username, 
-{
-host: '<aws-instance-public-ip>', port: 9000, path: '/myapp',
-config: {'iceServers': [
-    { url: 'stun:stun.l.google.com:19302' },
-    { url: 'turn:<aws-instance-public-ip>:3478', credential: 'deai', username: 'deai' }
-  ]} 
-}
-)
+// peer = new Peer(username, 
+// {
+// host: '<aws-instance-public-ip>', port: 9000, path: '/myapp',
+// config: {'iceServers': [
+//     { url: 'stun:stun.l.google.com:19302' },
+//     { url: 'turn:<aws-instance-public-ip>:3478', credential: 'deai', username: 'deai' }
+//   ]} 
+// }
+// )
 
 peer.on('connection', (conn) => {
   console.log('new connection')
   conn.on('open',function(){
   conn.on('data', (data) => {
+    res = new Uint8Array(data['msg'])
     console.log(data);
+    assignWeightsToModel(msgpack.decode(res), model);
   })})
 })
 }
 
-function send() {
+async function send() {
   const receiver = document.getElementById("receiver").value
-  const data = document.getElementById("message").value
+  
+  const msg = msgpack.encode(await serializeModel(model));
+  console.log(msg);
+  data = {'epoch': 0, 'msg': msg}
+
   const conn = peer.connect(receiver)
 
   conn.on('open', () => {

--- a/peerjs-backend/modelbuilder.js
+++ b/peerjs-backend/modelbuilder.js
@@ -1,0 +1,76 @@
+class ModelBuilder {
+  constructor(ref, mode = "build", global = window) {
+    this.args = {}
+    this.args_serial = {}
+    this.global = global
+
+    if (mode === "build") {
+      console.assert(ref.lib === "tf") // TODO remove in future
+      this.model = global[ref.lib][ref.func](...ref.args)
+      this.model_constructor = {lib : ref.lib, func : ref.func, args : ref.args}
+      this.actions = []
+
+    } else if (mode === "inject") {
+      console.assert(ref.model_constructor.lib === "tf") // TODO remove in future
+      this.model = global[ref.model_constructor.lib][ref.model_constructor.func](...ref.model_constructor.args)
+      this.model_constructor = ref.model_constructor
+      this.actions = ref.actions
+      
+      Object.keys(ref.args).forEach((k) => {this.compute_arg(k, ref.args[k].path, ...ref.args[k].args)})
+      ref.actions.forEach((v) => {this._apply(v.name, v.args)})
+    }
+  }
+
+  compute_arg(name, func_path, ...args) {
+    this.args[name] = this._compute(this.global, func_path, ...args)
+    this.args_serial[name] = {path : func_path, args : args}
+    return this.args[name]
+  }
+
+  _compute(namespace, func_path, ...args) {
+    var func = namespace[func_path[0]]
+    for (var i = 1; i < func_path.length; i++) {
+      func = func[func_path[i]]
+    }
+    var res = func(...args)
+    return res
+  }
+
+  _apply(func_name, ...args) {
+    var arg_array = []
+    for (var i = 0; i < args.length; i++) {
+      arg_array.push(this.args[args[i]])
+    }
+
+    this.model[func_name](...arg_array)
+  }
+
+  apply(func_name, ...args) {
+    this._apply(func_name, ...args)
+    this.actions.push({name : func_name, args : args})
+  }
+
+  set_model_constructor(constr) {
+    this.constructor = constr
+  }
+
+  set_actions(actions) {
+    this.actions = actions
+  }
+
+  get_model_constructor() {
+    return this.model_constructor
+  }
+
+  get_actions() {
+    return this.actions
+  }
+
+  get_args() {
+    return this.args_serial
+  }
+
+  get_model() {
+    return this.model
+  }
+}

--- a/peerjs-backend/peer.js
+++ b/peerjs-backend/peer.js
@@ -1,0 +1,44 @@
+//const msgpack = require("msgpack-lite");
+
+
+// trying to reproduce an Enum
+const CMD_CODES = {
+    ASSIGN_WEIGHTS  : 0,
+    TRAIN_INFO      : 1,
+    MODEL_INFO      : 2,
+}
+
+Object.freeze(CMD_CODES)
+
+class PeerJS {
+    constructor(local_peer, handle_data, ...handle_data_args) {
+        this.local_peer = local_peer
+        this.data = null
+        this.handle_data = handle_data
+        this.handle_data_args = handle_data_args
+
+        console.log(local_peer)
+        this.local_peer.on("connection", (conn) => {
+            console.log("new connection")
+            conn.on("data", (data) => {
+                this.data = data
+                this.new_data = true
+                this.handle_data(data, ...this.handle_data_args)
+            })
+        })
+    }
+
+    async send(receiver, data) {
+        const msg = msgpack.encode(data);
+        const conn = this.local_peer.connect(receiver)
+        conn.on('open', () => {
+            conn.send(data)
+        })
+    }
+
+    get_data() {
+        this.new_data = false
+        return this.data
+    }
+}
+

--- a/peerjs-backend/receiver.html
+++ b/peerjs-backend/receiver.html
@@ -1,0 +1,81 @@
+<html>
+  <body>
+<div>
+<input type="text" placeholder="Username" id="username">
+<button onclick="register()">Register</button>
+</div>
+
+<script src="https://unpkg.com/peerjs@1.3.1/dist/peerjs.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@2.0.0/dist/tf.min.js"></script>
+<script src="https://rawgit.com/kawanet/msgpack-lite/master/dist/msgpack.min.js"></script>
+<script src="./modelbuilder.js"></script>
+<script src="./peer.js"></script>
+
+<script>
+console.log('start')
+
+async function serializeTensor(tensor) {
+    return {
+        "$tensor": {
+            "data": await tensor.data(), // doesn't copy (maybe depending on runtime)!
+            "shape": tensor.shape,
+            "dtype": tensor.dtype
+        }
+    }
+}
+function deserializeTensor(dict) {
+    const {data, shape, dtype} = dict["$tensor"];
+    return tf.tensor(data, shape, dtype); // doesn't copy (maybe depending on runtime)!
+}
+async function serializeVariable(variable) {
+    return {
+        "$variable": {
+            "name": variable.name,
+            "val": await serializeTensor(variable.val),
+        }
+    }
+}
+
+async function serializeModel(model) {
+    return await Promise.all(model.weights.map(serializeVariable));
+}
+
+function assignWeightsToModel(serializedWeights, model) {
+    // This assumes the weights are in the right order
+    model.weights.forEach((weight, idx) => {
+        const serializedWeight = serializedWeights[idx]["$variable"];
+        const tensor = deserializeTensor(serializedWeight.val);
+        weight.val.assign(tensor);
+        tensor.dispose();
+    });
+}
+
+peerjs = null
+model = null
+
+function handle_data(data, model) {
+    console.log("Received data!")
+    console.log(data)
+    switch(data.cmd_code) {
+        case CMD_CODES.MODEL_INFO:
+            mbuilder = new ModelBuilder(data.payload, mode="inject")
+            model = mbuilder.get_model()
+            console.log(model)
+            break
+        case CMD_CODES.ASSIGN_WEIGHTS:
+            assignWeightsToModel(data.payload, model)
+            break
+    }
+}
+
+function register() {
+  const username = document.getElementById("username").value
+
+  peer = new Peer(username, {host: 'localhost', port: 9000, path: '/myapp'})
+  peerjs = new PeerJS(peer, handle_data, model)
+
+}
+
+</script>
+  </body>
+</html>

--- a/peerjs-backend/sender.html
+++ b/peerjs-backend/sender.html
@@ -1,0 +1,107 @@
+<html>
+  <body>
+<div>
+<input type="text" placeholder="Username" id="username">
+<button onclick="register()">Register</button>
+</div>
+
+<div>
+<input type="text" placeholder="Receiver" id="receiver">
+<button onclick="send()">Send</button>
+</div>
+
+<script src="https://unpkg.com/peerjs@1.3.1/dist/peerjs.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@2.0.0/dist/tf.min.js"></script>
+<script src="https://rawgit.com/kawanet/msgpack-lite/master/dist/msgpack.min.js"></script>
+<script src="./modelbuilder.js"></script>
+<script src="./peer.js"></script>
+
+<script>
+console.log('start')
+
+async function serializeTensor(tensor) {
+    return {
+        "$tensor": {
+            "data": await tensor.data(), // doesn't copy (maybe depending on runtime)!
+            "shape": tensor.shape,
+            "dtype": tensor.dtype
+        }
+    }
+}
+function deserializeTensor(dict) {
+    const {data, shape, dtype} = dict["$tensor"];
+    return tf.tensor(data, shape, dtype); // doesn't copy (maybe depending on runtime)!
+}
+async function serializeVariable(variable) {
+    return {
+        "$variable": {
+            "name": variable.name,
+            "val": await serializeTensor(variable.val),
+        }
+    }
+}
+
+async function serializeModel(model) {
+    return await Promise.all(model.weights.map(serializeVariable));
+}
+
+function assignWeightsToModel(serializedWeights, model) {
+    // This assumes the weights are in the right order
+    model.weights.forEach((weight, idx) => {
+        const serializedWeight = serializedWeights[idx]["$variable"];
+        const tensor = deserializeTensor(serializedWeight.val);
+        weight.val.assign(tensor);
+        tensor.dispose();
+    });
+}
+
+var modelbuilder = new ModelBuilder({lib : "tf", func : "sequential", args: []})
+modelbuilder.compute_arg("layer1", ["tf", "layers", "dense"], {units: 32, inputShape: [50]})
+modelbuilder.compute_arg("layer2", ["tf", "layers", "dense"], {units: 4})
+modelbuilder.apply("add", "layer1");
+modelbuilder.apply("add", "layer2");
+
+const model_data = {
+    model_constructor   : modelbuilder.get_model_constructor(),
+    actions             : modelbuilder.get_actions(),
+    args                : modelbuilder.get_args()
+}
+
+const send_data = {
+    cmd_code    : CMD_CODES.MODEL_INFO,
+    payload     : model_data
+}
+
+const model = modelbuilder.get_model()
+peerjs = null
+
+function handle_data(data, model) {
+    switch(data.cmd_code) {
+        case CMD_CODES.MODEL_INFO:
+            mbuilder = new ModelBuilder(data.payload, mode="inject")
+            model = mbuilder.get_model()
+            break
+        case CMD_CODES.ASSIGN_WEIGHTS:
+            assignWeightsToModel(data.payload, model)
+            break
+    }
+}
+
+function register() {
+  const username = document.getElementById("username").value
+
+  peer = new Peer(username, {host: 'localhost', port: 9000, path: '/myapp'})
+  peerjs = new PeerJS(peer, handle_data, model)
+
+}
+
+async function send() {
+    const receiver = document.getElementById("receiver").value
+    console.log(send_data)
+    peerjs.send(receiver, send_data)
+
+}
+
+</script>
+  </body>
+</html>


### PR DESCRIPTION
This adds some more functionality to the `tensorflow-peerjs` branch with the `PeerJS` and `ModelBuilder` classes. Specifically:
* `PeerJS` is a wrapper around the PeerJS library and allows to send/receive arbitrary data and handle it with any input function. The same module also defines "command codes" to determine what to do with the data (is it a description of the model? model weights? etc...)
* `ModelBuilder` is a basic tracing object that keeps track of how a model was built and is able to serialize/deserialize it. This way a model can be sent from one peer to another. It's not very advanced yet and there might be better approaches to implement this.

Finally there is a small demo, with `sender.html` and `receiver.html` that shows how a peer can send a model to another one. I haven't implemented weight injection in the demo yet but the infrastructure to do so is in place. 

To run this demo, you will need to set up a local PeerJS server running on `localhost:9000` (https://github.com/peers/peerjs-server):
```bash
npm install peer -g
peerjs --port 9000 --key peerjs --path /myapp
```
Once this is done, just open `sender.html` and `receiver.html`, register a username on both tabs and click "Send" on the sender tab. You will see all the action in the console.