### PR TITLE
Exchanging model architecture and training data

### DIFF
--- a/peerjs-backend/helpers.js
+++ b/peerjs-backend/helpers.js
@@ -1,0 +1,62 @@
+async function serializeTensor(tensor) {
+    return {
+        "$tensor": {
+            "data": await tensor.data(), // doesn't copy (maybe depending on runtime)!
+            "shape": tensor.shape,
+            "dtype": tensor.dtype
+        }
+    }
+}
+function deserializeTensor(dict) {
+    const {data, shape, dtype} = dict["$tensor"];
+    return tf.tensor(data, shape, dtype); // doesn't copy (maybe depending on runtime)!
+}
+async function serializeVariable(variable) {
+    return {
+        "$variable": {
+            "name": variable.name,
+            "val": await serializeTensor(variable.val),
+        }
+    }
+}
+
+async function serializeModel(model) {
+    return await Promise.all(model.weights.map(serializeVariable));
+}
+
+function assignWeightsToModel(serializedWeights, model) {
+    // This assumes the weights are in the right order
+    model.weights.forEach((weight, idx) => {
+        const serializedWeight = serializedWeights[idx]["$variable"];
+        const tensor = deserializeTensor(serializedWeight.val);
+        weight.val.assign(tensor);
+        tensor.dispose();
+    });
+}
+
+function averageWeightsIntoModel(serializedWeights, model) {
+    model.weights.forEach((weight, idx) => {
+        const serializedWeight = serializedWeights[idx]["$variable"];
+        const tensor = deserializeTensor(serializedWeight.val);
+        weight.val.assign(tensor.add(weight).div(2)); //average
+        tensor.dispose();
+    });
+}
+
+function* dataGenerator() {
+    for (let i = 0; i < 100; i++) {
+        // Generate one sample at a time.
+        yield tf.randomNormal([784]);
+    }
+}
+   
+function* labelGenerator() {
+    for (let i = 0; i < 100; i++) {
+        // Generate one sample at a time.
+        yield tf.randomUniform([10]);
+    }
+}
+
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/peerjs-backend/index.html
+++ b/peerjs-backend/index.html
@@ -7,44 +7,91 @@
 
 <div>
 <input type="text" placeholder="Receiver" id="receiver">
-<input type="text" placeholder="Message" id="message">
 <button onclick="send()">Send</button>
 </div>
 
 <script src="https://unpkg.com/peerjs@1.3.1/dist/peerjs.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@2.0.0/dist/tf.min.js"></script>
+<script src="https://rawgit.com/kawanet/msgpack-lite/master/dist/msgpack.min.js"></script>
 <script>
 console.log('start')
 
+async function serializeTensor(tensor) {
+    return {
+        "$tensor": {
+            "data": await tensor.data(), // doesn't copy (maybe depending on runtime)!
+            "shape": tensor.shape,
+            "dtype": tensor.dtype
+        }
+    }
+}
+function deserializeTensor(dict) {
+    const {data, shape, dtype} = dict["$tensor"];
+    return tf.tensor(data, shape, dtype); // doesn't copy (maybe depending on runtime)!
+}
+async function serializeVariable(variable) {
+    return {
+        "$variable": {
+            "name": variable.name,
+            "val": await serializeTensor(variable.val),
+        }
+    }
+}
+
+async function serializeModel(model) {
+    return await Promise.all(model.weights.map(serializeVariable));
+}
+
+function assignWeightsToModel(serializedWeights, model) {
+    // This assumes the weights are in the right order
+    model.weights.forEach((weight, idx) => {
+        const serializedWeight = serializedWeights[idx]["$variable"];
+        const tensor = deserializeTensor(serializedWeight.val);
+        weight.val.assign(tensor);
+        tensor.dispose();
+    });
+}
+
 peer = null
+const model = tf.sequential();
+model.add(tf.layers.dense({units: 32, inputShape: [50]}));
+model.add(tf.layers.dense({units: 4}));
+
 function register() {
   const username = document.getElementById("username").value
 
 // Uncomment this to use the public peerjs server without turn server
-// peer = new Peer(username)
+peer = new Peer(username, {host: 'localhost', port: 9000, path: '/myapp'})
 
 // Remove config property to disable the use of a turn server
-peer = new Peer(username, 
-{
-host: '<aws-instance-public-ip>', port: 9000, path: '/myapp',
-config: {'iceServers': [
-    { url: 'stun:stun.l.google.com:19302' },
-    { url: 'turn:<aws-instance-public-ip>:3478', credential: 'deai', username: 'deai' }
-  ]} 
-}
-)
+// peer = new Peer(username, 
+// {
+// host: '<aws-instance-public-ip>', port: 9000, path: '/myapp',
+// config: {'iceServers': [
+//     { url: 'stun:stun.l.google.com:19302' },
+//     { url: 'turn:<aws-instance-public-ip>:3478', credential: 'deai', username: 'deai' }
+//   ]} 
+// }
+// )
 
 peer.on('connection', (conn) => {
   console.log('new connection')
   conn.on('open',function(){
   conn.on('data', (data) => {
+    res = new Uint8Array(data['msg'])
     console.log(data);
+    assignWeightsToModel(msgpack.decode(res), model);
   })})
 })
 }
 
-function send() {
+async function send() {
   const receiver = document.getElementById("receiver").value
-  const data = document.getElementById("message").value
+  
+  const msg = msgpack.encode(await serializeModel(model));
+  console.log(msg);
+  data = {'epoch': 0, 'msg': msg}
+
   const conn = peer.connect(receiver)
 
   conn.on('open', () => {

--- a/peerjs-backend/modelbuilder.js
+++ b/peerjs-backend/modelbuilder.js
@@ -1,0 +1,76 @@
+class ModelBuilder {
+  constructor(ref, mode = "build", global = window) {
+    this.args = {}
+    this.args_serial = {}
+    this.global = global
+
+    if (mode === "build") {
+      console.assert(ref.lib === "tf") // TODO remove in future
+      this.model = global[ref.lib][ref.func](...ref.args)
+      this.model_constructor = {lib : ref.lib, func : ref.func, args : ref.args}
+      this.actions = []
+
+    } else if (mode === "inject") {
+      console.assert(ref.model_constructor.lib === "tf") // TODO remove in future
+      this.model = global[ref.model_constructor.lib][ref.model_constructor.func](...ref.model_constructor.args)
+      this.model_constructor = ref.model_constructor
+      this.actions = ref.actions
+      
+      Object.keys(ref.args).forEach((k) => {this.compute_arg(k, ref.args[k].path, ...ref.args[k].args)})
+      ref.actions.forEach((v) => {this._apply(v.name, v.args)})
+    }
+  }
+
+  compute_arg(name, func_path, ...args) {
+    this.args[name] = this._compute(this.global, func_path, ...args)
+    this.args_serial[name] = {path : func_path, args : args}
+    return this.args[name]
+  }
+
+  _compute(namespace, func_path, ...args) {
+    var func = namespace[func_path[0]]
+    for (var i = 1; i < func_path.length; i++) {
+      func = func[func_path[i]]
+    }
+    var res = func(...args)
+    return res
+  }
+
+  _apply(func_name, ...args) {
+    var arg_array = []
+    for (var i = 0; i < args.length; i++) {
+      arg_array.push(this.args[args[i]])
+    }
+
+    this.model[func_name](...arg_array)
+  }
+
+  apply(func_name, ...args) {
+    this._apply(func_name, ...args)
+    this.actions.push({name : func_name, args : args})
+  }
+
+  set_model_constructor(constr) {
+    this.constructor = constr
+  }
+
+  set_actions(actions) {
+    this.actions = actions
+  }
+
+  get_model_constructor() {
+    return this.model_constructor
+  }
+
+  get_actions() {
+    return this.actions
+  }
+
+  get_args() {
+    return this.args_serial
+  }
+
+  get_model() {
+    return this.model
+  }
+}

--- a/peerjs-backend/peer.js
+++ b/peerjs-backend/peer.js
@@ -6,6 +6,8 @@ const CMD_CODES = {
     ASSIGN_WEIGHTS  : 0,
     TRAIN_INFO      : 1,
     MODEL_INFO      : 2,
+    COMPILE_MODEL   : 3,
+    AVG_WEIGHTS     : 4,
 }
 
 Object.freeze(CMD_CODES)
@@ -42,6 +44,7 @@ class PeerJS {
     }
 }
 
+// TODO: this doesn't need to be a class...
 class ModelStorage {
 
     static get BASEDIR() {
@@ -93,10 +96,22 @@ async function send_model(model, peerjs, receiver, name) {
         cmd_code    : CMD_CODES.MODEL_INFO,
         payload     : serialized
     }
+    console.log("Sending model data")
+    console.log(send_data)
+    peerjs.send(receiver, send_data)
+}
+
+function send_data(data, code, peerjs, receiver) {
+    const send_data = {
+        cmd_code    : code,
+        payload     : data
+    }
+
     console.log("Sending data")
     console.log(send_data)
     peerjs.send(receiver, send_data)
 }
+
 
 async function load_model(model_data) {
     var name = model_data.name
@@ -106,3 +121,24 @@ async function load_model(model_data) {
     return model
 }
 
+async function handle_data(data, buffer) {
+    console.log("Received new data!")
+    console.log(data)
+    switch(data.cmd_code) {
+        case CMD_CODES.MODEL_INFO:
+            buffer.model = data.payload
+            break
+        case CMD_CODES.ASSIGN_WEIGHTS:
+            buffer.assign_weights = data.payload
+            break
+        case CMD_CODES.COMPILE_MODEL:
+            buffer.compile_data = data.payload
+            break
+        case CMD_CODES.AVG_WEIGHTS:
+            buffer.avg_weights = data.payload
+            break
+        case CMD_CODES.TRAIN_INFO:
+            buffer.train_info = data.payload
+            break
+    }
+}

--- a/peerjs-backend/peer.js
+++ b/peerjs-backend/peer.js
@@ -1,0 +1,44 @@
+//const msgpack = require("msgpack-lite");
+
+
+// trying to reproduce an Enum
+const CMD_CODES = {
+    ASSIGN_WEIGHTS  : 0,
+    TRAIN_INFO      : 1,
+    MODEL_INFO      : 2,
+}
+
+Object.freeze(CMD_CODES)
+
+class PeerJS {
+    constructor(local_peer, handle_data, ...handle_data_args) {
+        this.local_peer = local_peer
+        this.data = null
+        this.handle_data = handle_data
+        this.handle_data_args = handle_data_args
+
+        console.log(local_peer)
+        this.local_peer.on("connection", (conn) => {
+            console.log("new connection")
+            conn.on("data", (data) => {
+                this.data = data
+                this.new_data = true
+                this.handle_data(data, ...this.handle_data_args)
+            })
+        })
+    }
+
+    async send(receiver, data) {
+        const msg = msgpack.encode(data);
+        const conn = this.local_peer.connect(receiver)
+        conn.on('open', () => {
+            conn.send(data)
+        })
+    }
+
+    get_data() {
+        this.new_data = false
+        return this.data
+    }
+}
+

--- a/peerjs-backend/peer.js
+++ b/peerjs-backend/peer.js
@@ -17,13 +17,13 @@ class PeerJS {
         this.handle_data = handle_data
         this.handle_data_args = handle_data_args
 
-        console.log(local_peer)
+        console.log("peer", local_peer)
         this.local_peer.on("connection", (conn) => {
             console.log("new connection")
-            conn.on("data", (data) => {
+            conn.on("data", async (data) => {
                 this.data = data
                 this.new_data = true
-                this.handle_data(data, ...this.handle_data_args)
+                await this.handle_data(data, ...this.handle_data_args)
             })
         })
     }
@@ -40,5 +40,69 @@ class PeerJS {
         this.new_data = false
         return this.data
     }
+}
+
+class ModelStorage {
+
+    static get BASEDIR() {
+        return "tensorflowjs_models"
+    }
+
+    static get FILENAMES() {
+        return [
+            "info",
+            "model_metadata",
+            "model_topology",
+            "weight_data",
+            "weight_specs"
+        ]
+    }
+
+    static async store(model, name) {
+        await model.save("localstorage://" + name)
+    }
+
+    static inject(model_data, name) {
+        for(var i = 0; i < this.FILENAMES; i++) {
+            var key = this.FILENAMES[i]
+            var fpath = this.BASEDIR + '/' + name + '/' + key
+            var content = model_data[key]
+            localStorage.setItem(fpath, content)
+        }
+    }
+
+    static get_serialized_model(name) {
+        var serialized = {}
+        for(var i = 0; i < this.FILENAMES.length; i++) {
+            var key = this.FILENAMES[i]
+            var fpath = this.BASEDIR + '/' + name + '/' + key
+
+            var model_data = localStorage.getItem(fpath) // this is a JSON string
+            serialized[key] = model_data
+        }
+        serialized.name = name
+        return serialized
+    }
+
+}
+
+async function send_model(model, peerjs, receiver, name) {
+    await ModelStorage.store(model, name)
+    var serialized = ModelStorage.get_serialized_model(name)
+    const send_data = {
+        cmd_code    : CMD_CODES.MODEL_INFO,
+        payload     : serialized
+    }
+    console.log("Sending data")
+    console.log(send_data)
+    peerjs.send(receiver, send_data)
+}
+
+async function load_model(model_data) {
+    var name = model_data.name
+    ModelStorage.inject(model_data, name)
+    const model = await tf.loadLayersModel("localstorage://" + name)
+    
+    return model
 }
 

--- a/peerjs-backend/receiver.html
+++ b/peerjs-backend/receiver.html
@@ -10,69 +10,41 @@
 <script src="https://rawgit.com/kawanet/msgpack-lite/master/dist/msgpack.min.js"></script>
 <script src="./modelbuilder.js"></script>
 <script src="./peer.js"></script>
-
+<script src="./helpers.js"></script>
 <script>
 console.log('start')
 
-async function serializeTensor(tensor) {
-    return {
-        "$tensor": {
-            "data": await tensor.data(), // doesn't copy (maybe depending on runtime)!
-            "shape": tensor.shape,
-            "dtype": tensor.dtype
-        }
-    }
-}
-function deserializeTensor(dict) {
-    const {data, shape, dtype} = dict["$tensor"];
-    return tf.tensor(data, shape, dtype); // doesn't copy (maybe depending on runtime)!
-}
-async function serializeVariable(variable) {
-    return {
-        "$variable": {
-            "name": variable.name,
-            "val": await serializeTensor(variable.val),
-        }
-    }
-}
-
-async function serializeModel(model) {
-    return await Promise.all(model.weights.map(serializeVariable));
-}
-
-function assignWeightsToModel(serializedWeights, model) {
-    // This assumes the weights are in the right order
-    model.weights.forEach((weight, idx) => {
-        const serializedWeight = serializedWeights[idx]["$variable"];
-        const tensor = deserializeTensor(serializedWeight.val);
-        weight.val.assign(tensor);
-        tensor.dispose();
-    });
-}
 
 var peerjs = null
 var model = null
+var recv_buffer = {}
 
-async function handle_data(data, model) {
-    console.log("Received new data!")
-    console.log(data)
-    switch(data.cmd_code) {
-        case CMD_CODES.MODEL_INFO:
-            model = await load_model(data.payload)
-            console.log(model)
-            break
-        case CMD_CODES.ASSIGN_WEIGHTS:
-            assignWeightsToModel(data.payload, model)
-            break
-    }
-}
-
-function register() {
+async function register() {
   const username = document.getElementById("username").value
 
   peer = new Peer(username, {host: 'localhost', port: 9000, path: '/myapp'})
-  peerjs = new PeerJS(peer, handle_data, model)
+  peerjs = new PeerJS(peer, handle_data, recv_buffer)
+  
+  data_received("model")
+    .then(() => data_received("compile_data"))
+    .then(() => data_received("train_info"))
+    .then(async () => {model = await load_model(recv_buffer.model)})
+    .then(() => {
+      model.compile(recv_buffer.compile_data)
+      console.log("Model: ", model)
+      console.log("Train info: ", recv_buffer.train_info)
+    });
+}
 
+function data_received(key) {
+  return new Promise( (resolve) => {
+    (function wait_data(){
+          if (recv_buffer[key]) {
+            return resolve();
+          }
+          setTimeout(wait_data, 100);
+      })();
+  });
 }
 
 </script>

--- a/peerjs-backend/receiver.html
+++ b/peerjs-backend/receiver.html
@@ -1,0 +1,81 @@
+<html>
+  <body>
+<div>
+<input type="text" placeholder="Username" id="username">
+<button onclick="register()">Register</button>
+</div>
+
+<script src="https://unpkg.com/peerjs@1.3.1/dist/peerjs.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@2.0.0/dist/tf.min.js"></script>
+<script src="https://rawgit.com/kawanet/msgpack-lite/master/dist/msgpack.min.js"></script>
+<script src="./modelbuilder.js"></script>
+<script src="./peer.js"></script>
+
+<script>
+console.log('start')
+
+async function serializeTensor(tensor) {
+    return {
+        "$tensor": {
+            "data": await tensor.data(), // doesn't copy (maybe depending on runtime)!
+            "shape": tensor.shape,
+            "dtype": tensor.dtype
+        }
+    }
+}
+function deserializeTensor(dict) {
+    const {data, shape, dtype} = dict["$tensor"];
+    return tf.tensor(data, shape, dtype); // doesn't copy (maybe depending on runtime)!
+}
+async function serializeVariable(variable) {
+    return {
+        "$variable": {
+            "name": variable.name,
+            "val": await serializeTensor(variable.val),
+        }
+    }
+}
+
+async function serializeModel(model) {
+    return await Promise.all(model.weights.map(serializeVariable));
+}
+
+function assignWeightsToModel(serializedWeights, model) {
+    // This assumes the weights are in the right order
+    model.weights.forEach((weight, idx) => {
+        const serializedWeight = serializedWeights[idx]["$variable"];
+        const tensor = deserializeTensor(serializedWeight.val);
+        weight.val.assign(tensor);
+        tensor.dispose();
+    });
+}
+
+peerjs = null
+model = null
+
+function handle_data(data, model) {
+    console.log("Received data!")
+    console.log(data)
+    switch(data.cmd_code) {
+        case CMD_CODES.MODEL_INFO:
+            mbuilder = new ModelBuilder(data.payload, mode="inject")
+            model = mbuilder.get_model()
+            console.log(model)
+            break
+        case CMD_CODES.ASSIGN_WEIGHTS:
+            assignWeightsToModel(data.payload, model)
+            break
+    }
+}
+
+function register() {
+  const username = document.getElementById("username").value
+
+  peer = new Peer(username, {host: 'localhost', port: 9000, path: '/myapp'})
+  peerjs = new PeerJS(peer, handle_data, model)
+
+}
+
+</script>
+  </body>
+</html>

--- a/peerjs-backend/receiver.html
+++ b/peerjs-backend/receiver.html
@@ -50,16 +50,15 @@ function assignWeightsToModel(serializedWeights, model) {
     });
 }
 
-peerjs = null
-model = null
+var peerjs = null
+var model = null
 
-function handle_data(data, model) {
-    console.log("Received data!")
+async function handle_data(data, model) {
+    console.log("Received new data!")
     console.log(data)
     switch(data.cmd_code) {
         case CMD_CODES.MODEL_INFO:
-            mbuilder = new ModelBuilder(data.payload, mode="inject")
-            model = mbuilder.get_model()
+            model = await load_model(data.payload)
             console.log(model)
             break
         case CMD_CODES.ASSIGN_WEIGHTS:

--- a/peerjs-backend/sender.html
+++ b/peerjs-backend/sender.html
@@ -1,0 +1,107 @@
+<html>
+  <body>
+<div>
+<input type="text" placeholder="Username" id="username">
+<button onclick="register()">Register</button>
+</div>
+
+<div>
+<input type="text" placeholder="Receiver" id="receiver">
+<button onclick="send()">Send</button>
+</div>
+
+<script src="https://unpkg.com/peerjs@1.3.1/dist/peerjs.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@2.0.0/dist/tf.min.js"></script>
+<script src="https://rawgit.com/kawanet/msgpack-lite/master/dist/msgpack.min.js"></script>
+<script src="./modelbuilder.js"></script>
+<script src="./peer.js"></script>
+
+<script>
+console.log('start')
+
+async function serializeTensor(tensor) {
+    return {
+        "$tensor": {
+            "data": await tensor.data(), // doesn't copy (maybe depending on runtime)!
+            "shape": tensor.shape,
+            "dtype": tensor.dtype
+        }
+    }
+}
+function deserializeTensor(dict) {
+    const {data, shape, dtype} = dict["$tensor"];
+    return tf.tensor(data, shape, dtype); // doesn't copy (maybe depending on runtime)!
+}
+async function serializeVariable(variable) {
+    return {
+        "$variable": {
+            "name": variable.name,
+            "val": await serializeTensor(variable.val),
+        }
+    }
+}
+
+async function serializeModel(model) {
+    return await Promise.all(model.weights.map(serializeVariable));
+}
+
+function assignWeightsToModel(serializedWeights, model) {
+    // This assumes the weights are in the right order
+    model.weights.forEach((weight, idx) => {
+        const serializedWeight = serializedWeights[idx]["$variable"];
+        const tensor = deserializeTensor(serializedWeight.val);
+        weight.val.assign(tensor);
+        tensor.dispose();
+    });
+}
+
+var modelbuilder = new ModelBuilder({lib : "tf", func : "sequential", args: []})
+modelbuilder.compute_arg("layer1", ["tf", "layers", "dense"], {units: 32, inputShape: [50]})
+modelbuilder.compute_arg("layer2", ["tf", "layers", "dense"], {units: 4})
+modelbuilder.apply("add", "layer1");
+modelbuilder.apply("add", "layer2");
+
+const model_data = {
+    model_constructor   : modelbuilder.get_model_constructor(),
+    actions             : modelbuilder.get_actions(),
+    args                : modelbuilder.get_args()
+}
+
+const send_data = {
+    cmd_code    : CMD_CODES.MODEL_INFO,
+    payload     : model_data
+}
+
+const model = modelbuilder.get_model()
+peerjs = null
+
+function handle_data(data, model) {
+    switch(data.cmd_code) {
+        case CMD_CODES.MODEL_INFO:
+            mbuilder = new ModelBuilder(data.payload, mode="inject")
+            model = mbuilder.get_model()
+            break
+        case CMD_CODES.ASSIGN_WEIGHTS:
+            assignWeightsToModel(data.payload, model)
+            break
+    }
+}
+
+function register() {
+  const username = document.getElementById("username").value
+
+  peer = new Peer(username, {host: 'localhost', port: 9000, path: '/myapp'})
+  peerjs = new PeerJS(peer, handle_data, model)
+
+}
+
+async function send() {
+    const receiver = document.getElementById("receiver").value
+    console.log(send_data)
+    peerjs.send(receiver, send_data)
+
+}
+
+</script>
+  </body>
+</html>

--- a/peerjs-backend/sender.html
+++ b/peerjs-backend/sender.html
@@ -10,73 +10,41 @@
 <button onclick="send()">Send</button>
 </div>
 
+
+
 <script src="https://unpkg.com/peerjs@1.3.1/dist/peerjs.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@2.0.0/dist/tf.min.js"></script>
 <script src="https://rawgit.com/kawanet/msgpack-lite/master/dist/msgpack.min.js"></script>
 <script src="./modelbuilder.js"></script>
 <script src="./peer.js"></script>
+<script src="./helpers.js"></script>
 
 <script>
 console.log('start')
 
-async function serializeTensor(tensor) {
-    return {
-        "$tensor": {
-            "data": await tensor.data(), // doesn't copy (maybe depending on runtime)!
-            "shape": tensor.shape,
-            "dtype": tensor.dtype
-        }
-    }
-}
-function deserializeTensor(dict) {
-    const {data, shape, dtype} = dict["$tensor"];
-    return tf.tensor(data, shape, dtype); // doesn't copy (maybe depending on runtime)!
-}
-async function serializeVariable(variable) {
-    return {
-        "$variable": {
-            "name": variable.name,
-            "val": await serializeTensor(variable.val),
-        }
-    }
-}
-
-async function serializeModel(model) {
-    return await Promise.all(model.weights.map(serializeVariable));
-}
-
-function assignWeightsToModel(serializedWeights, model) {
-    // This assumes the weights are in the right order
-    model.weights.forEach((weight, idx) => {
-        const serializedWeight = serializedWeights[idx]["$variable"];
-        const tensor = deserializeTensor(serializedWeight.val);
-        weight.val.assign(tensor);
-        tensor.dispose();
-    });
-}
 
 const model = tf.sequential();
 model.add(tf.layers.dense({units: 32, inputShape: [50]}));
 model.add(tf.layers.dense({units: 4}));
 
-var peerjs = null
-
-async function handle_data(data, model) {
-    switch(data.cmd_code) {
-        case CMD_CODES.MODEL_INFO:
-            model = await load_model(data.payload)
-            break
-        case CMD_CODES.ASSIGN_WEIGHTS:
-            assignWeightsToModel(data.payload, model)
-            break
-    }
+const model_compile_data = {
+  optimizer   : 'sgd',
+  loss        : 'categoricalCrossentropy',
+  metrics     : ['accuracy']
 }
+
+const model_train_data = {
+  epochs  : 5
+}
+
+var peerjs = null
+recv_buffer = {}
 
 function register() {
   const username = document.getElementById("username").value
 
   peer = new Peer(username, {host: 'localhost', port: 9000, path: '/myapp'})
-  peerjs = new PeerJS(peer, handle_data, model)
+  peerjs = new PeerJS(peer, handle_data, recv_buffer)
 
 }
 
@@ -95,7 +63,9 @@ function makeid(length) {
 async function send() {
     const receiver = document.getElementById("receiver").value
     var name = makeid(10)
-    send_model(model, peerjs, receiver, name)
+    await send_model(model, peerjs, receiver, name)
+    await send_data(model_compile_data, CMD_CODES.COMPILE_MODEL, peerjs, receiver)
+    await send_data(model_train_data, CMD_CODES.TRAIN_INFO, peerjs, receiver)
 }
 
 

--- a/peerjs-backend/sender.html
+++ b/peerjs-backend/sender.html
@@ -55,31 +55,16 @@ function assignWeightsToModel(serializedWeights, model) {
     });
 }
 
-var modelbuilder = new ModelBuilder({lib : "tf", func : "sequential", args: []})
-modelbuilder.compute_arg("layer1", ["tf", "layers", "dense"], {units: 32, inputShape: [50]})
-modelbuilder.compute_arg("layer2", ["tf", "layers", "dense"], {units: 4})
-modelbuilder.apply("add", "layer1");
-modelbuilder.apply("add", "layer2");
+const model = tf.sequential();
+model.add(tf.layers.dense({units: 32, inputShape: [50]}));
+model.add(tf.layers.dense({units: 4}));
 
-const model_data = {
-    model_constructor   : modelbuilder.get_model_constructor(),
-    actions             : modelbuilder.get_actions(),
-    args                : modelbuilder.get_args()
-}
+var peerjs = null
 
-const send_data = {
-    cmd_code    : CMD_CODES.MODEL_INFO,
-    payload     : model_data
-}
-
-const model = modelbuilder.get_model()
-peerjs = null
-
-function handle_data(data, model) {
+async function handle_data(data, model) {
     switch(data.cmd_code) {
         case CMD_CODES.MODEL_INFO:
-            mbuilder = new ModelBuilder(data.payload, mode="inject")
-            model = mbuilder.get_model()
+            model = await load_model(data.payload)
             break
         case CMD_CODES.ASSIGN_WEIGHTS:
             assignWeightsToModel(data.payload, model)
@@ -95,12 +80,24 @@ function register() {
 
 }
 
+// for random string
+function makeid(length) {
+   var result           = '';
+   var characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+   var charactersLength = characters.length;
+   for ( var i = 0; i < length; i++ ) {
+      result += characters.charAt(Math.floor(Math.random() * charactersLength));
+   }
+   return result;
+}
+
+
 async function send() {
     const receiver = document.getElementById("receiver").value
-    console.log(send_data)
-    peerjs.send(receiver, send_data)
-
+    var name = makeid(10)
+    send_model(model, peerjs, receiver, name)
 }
+
 
 </script>
   </body>


### PR DESCRIPTION
Implements:
- Exchanging model architecture between peers with `tf.save` and `tf.loadLayersModel`. The model is saved to `localStorage`, then sent as a string and reconstructed by the peer
- Exchanging training information to compile the model, e.g: 
```js 
model.compile({ // this object can be sent to peers
  optimizer: 'sgd',
  loss: 'categoricalCrossentropy',
  metrics: ['accuracy']
})
```
- Exchanging number of epochs, which is passed to `model.fit` or `model.fitDataset`

Not included in prototype (but code is ready):
- Exchange weights to inject into model
- Exchange weights to average into model

To get the demo working, see PR #19 