### PR TITLE
Training with n peers on MNIST

### DIFF
--- a/peerjs-backend/helpers.js
+++ b/peerjs-backend/helpers.js
@@ -64,14 +64,25 @@ function sleep(ms) {
 
 function data_received(recv_buffer, key) {
     return new Promise( (resolve) => {
-      (function wait_data(){
+        (function wait_data(){
             if (recv_buffer[key]) {
-              return resolve();
+                return resolve();
             }
             setTimeout(wait_data, 100);
         })();
     });
-  }
+}
+
+function check_array_len(arr, len) {
+    return new Promise( (resolve) => {
+        (function wait_data(){
+            if (arr.length === len) {
+                return resolve();
+            }
+            setTimeout(wait_data, 100);
+        })();
+    });
+}
 
 // for random string
 function makeid(length) {

--- a/peerjs-backend/helpers.js
+++ b/peerjs-backend/helpers.js
@@ -44,6 +44,7 @@ function averageWeightsIntoModel(serializedWeights, model) {
     });
 }
 
+//////////// TESTING functions - generate random data and labels
 function* dataGenerator() {
     for (let i = 0; i < 100; i++) {
         // Generate one sample at a time.
@@ -57,6 +58,7 @@ function* labelGenerator() {
         yield tf.randomUniform([10]);
     }
 }
+///////////////////////////////////////////////
 
 function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
@@ -73,6 +75,12 @@ function data_received(recv_buffer, key) {
     });
 }
 
+/**
+ * Waits until an array reaches a given length. Used to make 
+ * sure that all weights from peers are received.
+ * @param {Array} arr 
+ * @param {int} len 
+ */
 function check_array_len(arr, len) {
     return new Promise( (resolve) => {
         (function wait_data(){
@@ -84,7 +92,7 @@ function check_array_len(arr, len) {
     });
 }
 
-// for random string
+// generates a random string
 function makeid(length) {
     var result           = '';
     var characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';

--- a/peerjs-backend/helpers.js
+++ b/peerjs-backend/helpers.js
@@ -37,7 +37,7 @@ function assignWeightsToModel(serializedWeights, model) {
 function averageWeightsIntoModel(serializedWeights, model) {
     model.weights.forEach((weight, idx) => {
         const serializedWeight = serializedWeights[idx]["$variable"];
-        console.log(serializedWeight.val)
+
         const tensor = deserializeTensor(serializedWeight.val);
         weight.val.assign(tensor.add(weight.val).div(2)); //average
         tensor.dispose();

--- a/peerjs-backend/mnist_data.js
+++ b/peerjs-backend/mnist_data.js
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2019 AI Lab - Telkom University. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */ 
+ 
+// require('babel-polyfill')
+
+const IMAGE_H = 28
+const IMAGE_W = 28
+const IMAGE_SIZE = IMAGE_H * IMAGE_W
+const N_CLASSES = 10
+const N_DATA  = 65000
+
+const MNIST_IMAGES_SPRITE_PATH =
+    'https://storage.googleapis.com/learnjs-data/model-builder/mnist_images.png'
+const MNIST_LABELS_PATH =
+    'https://storage.googleapis.com/learnjs-data/model-builder/mnist_labels_uint8'
+    
+
+class MnistData {
+    constructor() {
+        this.isDownloaded = false
+    }
+
+    async load(nTrain = 40000, nTest  = 10000) {
+        // Make a request for the MNIST sprited image.
+        const img = new Image()
+        const canvas = document.createElement('canvas')
+        const ctx = canvas.getContext('2d')
+        const imgRequest = new Promise((resolve, reject) => {
+            img.crossOrigin = ''
+            img.onload = () => {
+                img.width = img.naturalWidth
+                img.height = img.naturalHeight
+
+                const datasetBytesBuffer =
+                    new ArrayBuffer(N_DATA * IMAGE_SIZE * 4)
+
+                const chunkSize = 5000
+                canvas.width = img.width
+                canvas.height = chunkSize
+
+                for (let i = 0; i < N_DATA / chunkSize; i++) {
+                    const datasetBytesView = new Float32Array(
+                        datasetBytesBuffer, i * IMAGE_SIZE * chunkSize * 4,
+                        IMAGE_SIZE * chunkSize)
+                    ctx.drawImage(
+                        img, 0, i * chunkSize, img.width, chunkSize, 0, 0, img.width,
+                        chunkSize)
+
+                    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height)
+
+                    for (let j = 0; j < imageData.data.length / 4; j++) {
+                    // All channels hold an equal value since the image is grayscale, so
+                    // just read the red channel.
+                        datasetBytesView[j] = imageData.data[j * 4] / 255
+                    }
+                }
+                this.datasetImages = new Float32Array(datasetBytesBuffer)
+                resolve()
+            }
+            img.src = MNIST_IMAGES_SPRITE_PATH
+        })
+
+        const labelsRequest = fetch(MNIST_LABELS_PATH)
+        const [imgResponse, labelsResponse] =
+            await Promise.all([imgRequest, labelsRequest])
+
+        this.datasetLabels = new Uint8Array(await labelsResponse.arrayBuffer())
+
+        // Slice the the images and labels into train and test sets.
+        this.trainImages =
+            this.datasetImages.slice(0, IMAGE_SIZE * nTrain)
+        this.testImages = this.datasetImages.slice(IMAGE_SIZE * nTrain, IMAGE_SIZE * (nTrain+nTest))
+        this.trainLabels =
+            this.datasetLabels.slice(0, N_CLASSES * nTrain)
+        this.testLabels =
+            this.datasetLabels.slice(N_CLASSES * nTrain, N_CLASSES * (nTrain+nTest))
+        this.isDownloaded = true
+    }
+    
+
+    /**
+    * Get all training data as a data tensor and a labels tensor.
+    *
+    * @returns
+    *   x_train: The data tensor, of shape `[numTrainExamples, 28, 28, 1]`.
+    *   y_train: The one-hot encoded labels tensor, of shape
+    *     `[numTrainExamples, 10]`.
+    */
+    getTrainData() {
+        const x_train = tf.tensor4d(
+                       this.trainImages,
+                       [this.trainImages.length / IMAGE_SIZE, IMAGE_H, IMAGE_W, 1])
+        const y_train = tf.tensor2d(
+                           this.trainLabels, [this.trainLabels.length / N_CLASSES, N_CLASSES])
+        return [x_train, y_train]
+    }
+
+    /**
+    * Get all test data as a data tensor a a labels tensor.
+    *
+    * @param {number} numExamples Optional number of examples to get. If not
+    *     provided,
+    *   all test examples will be returned.
+    * @returns
+    *   x_test: The data tensor, of shape `[numTestExamples, 28, 28, 1]`.
+    *   y_test: The one-hot encoded labels tensor, of shape
+    *     `[numTestExamples, 10]`.
+    */
+    getTestData(numExamples) {
+        let x_test = tf.tensor4d(
+                     this.testImages,
+                     [this.testImages.length / IMAGE_SIZE, IMAGE_H, IMAGE_W, 1])
+        let y_test = tf.tensor2d(
+                         this.testLabels, [this.testLabels.length / N_CLASSES, N_CLASSES])
+
+        if (numExamples != null) {
+            x_test = x_test.slice([0, 0, 0, 0], [numExamples, IMAGE_H, IMAGE_W, 1])
+            y_test = y_test.slice([0, 0], [numExamples, N_CLASSES])
+        }
+        return [x_test, y_test]
+    }
+}
+
+// modified from https://github.com/tensorflow/tfjs-examples/blob/master/mnist-core/data.js
+// @author ANDITYA ARIFIANTO
+// AI LAB - 2019

--- a/peerjs-backend/peer.js
+++ b/peerjs-backend/peer.js
@@ -100,9 +100,9 @@ class ModelStorage {
     }
 
     /**
-     * 
-     * @param {*} model_data 
-     * @param {*} name 
+     * Save serialized model to LocalStorage for future loading
+     * @param {object} model_data serialized model
+     * @param {String} name name, can be anything
      */
     static inject(model_data, name) {
         for(var i = 0; i < this.FILENAMES; i++) {
@@ -113,6 +113,10 @@ class ModelStorage {
         }
     }
 
+    /**
+     * Get serialized model from LocalStorage
+     * @param {String} name name used to save the model
+     */
     static get_serialized_model(name) {
         var serialized = {}
         for(var i = 0; i < this.FILENAMES.length; i++) {
@@ -127,6 +131,13 @@ class ModelStorage {
     }
 }
 
+/**
+ * Send a serialized TFJS model to a remote peer
+ * @param {TFJS model} model the model to send
+ * @param {PeerJS} peerjs instance of PeerJS object
+ * @param {String} receiver receiver name (must be registered in PeerJS server)
+ * @param {String} name name to save the model with, can be anything
+ */
 async function send_model(model, peerjs, receiver, name) {
     await ModelStorage.store(model, name)
     var serialized = ModelStorage.get_serialized_model(name)
@@ -139,6 +150,13 @@ async function send_model(model, peerjs, receiver, name) {
     peerjs.send(receiver, send_data)
 }
 
+/**
+ * Send data to a remote peer
+ * @param {object} data data to send
+ * @param {int} code code in CMD_CODES to identify what the data is for
+ * @param {PeerJS} peerjs PeerJS object
+ * @param {String} receiver name of receiver peer (must be registered in PeerJS server)
+ */
 function send_data(data, code, peerjs, receiver) {
     const send_data = {
         cmd_code    : code,
@@ -150,7 +168,10 @@ function send_data(data, code, peerjs, receiver) {
     peerjs.send(receiver, send_data)
 }
 
-
+/**
+ * Deserialize a received model 
+ * @param {object} model_data serialized model
+ */
 async function load_model(model_data) {
     var name = model_data.name
     ModelStorage.inject(model_data, name)
@@ -159,6 +180,11 @@ async function load_model(model_data) {
     return model
 }
 
+/**
+ * Function given to PeerJS instance to handle incoming data
+ * @param {object} data incoming data 
+ * @param {object} buffer buffer to store data
+ */
 async function handle_data(data, buffer) {
     console.log("Received new data: ", data)
 

--- a/peerjs-backend/peer.js
+++ b/peerjs-backend/peer.js
@@ -27,7 +27,7 @@ class PeerJS {
 
         console.log("peer", local_peer)
         this.local_peer.on("connection", (conn) => {
-            console.log("new connection")
+            console.log("new connection from", conn.peer)
             conn.on("data", async (data) => {
                 this.data = data
                 this.new_data = true
@@ -91,7 +91,6 @@ class ModelStorage {
         serialized.name = name
         return serialized
     }
-
 }
 
 async function send_model(model, peerjs, receiver, name) {
@@ -142,7 +141,20 @@ async function handle_data(data, buffer) {
             buffer.compile_data = payload
             break
         case CMD_CODES.AVG_WEIGHTS:
-            buffer.avg_weights = payload
+
+            if (buffer.avg_weights === undefined) {
+                buffer.avg_weights = {}
+            }
+
+            const epoch = payload.epoch
+            const weights = payload.weights
+
+            if (buffer.avg_weights[epoch] === undefined) {
+                buffer.avg_weights[epoch] = [weights]
+            } else {
+                buffer.avg_weights[epoch].push(weights)
+            }
+            console.log("#Weights: ", buffer.avg_weights[epoch].length)
             break
         case CMD_CODES.TRAIN_INFO:
             buffer.train_info = payload

--- a/peerjs-backend/receiver.html
+++ b/peerjs-backend/receiver.html
@@ -6,7 +6,7 @@
 </div>
 
 <div>
-  <input type="text" placeholder="Sender" id="sender">
+  <input type="text" placeholder="Receivers" id="receivers">
 </div>
 
 <div>
@@ -24,13 +24,13 @@ console.log('start')
 
 var peerjs = null
 var model = null
-var sender = null
+var receivers = null
 var recv_buffer = {}
 var epoch = 0
 
 async function register() {
   const username = document.getElementById("username").value
-  sender = document.getElementById("sender").value
+  receivers = document.getElementById("receivers").value.split(',')
 
   peer = new Peer(username, {host: 'localhost', port: 9000, path: '/myapp'})
   peerjs = new PeerJS(peer, handle_data, recv_buffer)
@@ -48,19 +48,34 @@ async function register() {
 }
 
 function onEpochBegin() {
-  console.log("EPOCH: ", epoch++)
+  console.log("EPOCH: ", ++epoch)
 }
 
 async function onEpochEnd() {
-  console.log("Sending weights")
   const serialized_weights = await serializeWeights(model)
+  const epoch_weights = {epoch : epoch, weights : serialized_weights}
 
-  await send_data(serialized_weights, CMD_CODES.AVG_WEIGHTS, peerjs, sender)
-  await data_received(recv_buffer, "avg_weights")
+  for (var i in receivers) {
+    console.log("Sending weights to: ", receivers[i])
+    await send_data(epoch_weights, CMD_CODES.AVG_WEIGHTS, peerjs, receivers[i])
+  }
+
+  if (recv_buffer.avg_weights === undefined) {
+    console.log("Waiting to receive weights...")
+    await data_received(recv_buffer, "avg_weights")
+  }
+  if (recv_buffer.avg_weights[epoch] === undefined) {
+    console.log("Waiting to receive weights for this epoch...")
+    await data_received(recv_buffer.avg_weights, epoch.toString())
+  }
+  console.log("Waiting to receive all weights for this epoch...")
+  await check_array_len(recv_buffer.avg_weights[epoch], receivers.length)
     .then(() => {
       console.log("Averaging weights")
-      averageWeightsIntoModel(recv_buffer.avg_weights, model)
-      delete recv_buffer.avg_weights
+      for(i in recv_buffer.avg_weights[epoch]) {
+        averageWeightsIntoModel(recv_buffer.avg_weights[epoch][i], model)
+      }
+      // delete recv_buffer.avg_weights
     })
 }
 

--- a/peerjs-backend/receiver.html
+++ b/peerjs-backend/receiver.html
@@ -29,6 +29,7 @@ var receivers = null
 var recv_buffer = {}
 var epoch = 0
 
+// register peer name on PeerJS server
 async function register() {
   const username = document.getElementById("username").value
   receivers = document.getElementById("receivers").value.split(',')
@@ -52,6 +53,10 @@ function onEpochBegin() {
   console.log("EPOCH: ", ++epoch)
 }
 
+/**
+ * Sends weights to all peers, waits to receive weights from all peers
+ * and then averages peers' weights into the model.
+*/
 async function onEpochEnd() {
   const serialized_weights = await serializeWeights(model)
   const epoch_weights = {epoch : epoch, weights : serialized_weights}
@@ -80,6 +85,7 @@ async function onEpochEnd() {
     })
 }
 
+// train model (might want to add shuffling here for the prototype)
 async function train() {
   const mnist = new MnistData()
   await mnist.load()

--- a/peerjs-backend/receiver.html
+++ b/peerjs-backend/receiver.html
@@ -18,6 +18,7 @@
 <script src="https://rawgit.com/kawanet/msgpack-lite/master/dist/msgpack.min.js"></script>
 <script src="./peer.js"></script>
 <script src="./helpers.js"></script>
+<script src="./mnist_data.js"></script>
 <script>
 console.log('start')
 
@@ -79,18 +80,20 @@ async function onEpochEnd() {
     })
 }
 
-const xs = tf.data.generator(dataGenerator);
-const ys = tf.data.generator(labelGenerator);
-
-const dataSet = tf.data.zip({xs, ys}).shuffle(100 /* bufferSize */).batch(32);
-
 async function train() {
+  const mnist = new MnistData()
+  await mnist.load()
+  const [x_train_2d, y_train_2d] = mnist.getTrainData()
+  const x_train_1d = tf.reshape(x_train_2d, [x_train_2d.shape[0], -1])
+  const y_train_1d = tf.reshape(y_train_2d, [y_train_2d.shape[0], -1])
+
   model.compile(recv_buffer.compile_data)
   console.log("Training started")
-  model.fitDataset(dataSet, {
+  await model.fit(x_train_1d, y_train_1d, {
     epochs : recv_buffer.train_info.epochs,
+    batchSize: 50,
     callbacks : {onEpochBegin, onEpochEnd}
-  })
+  }).then((info) => console.log("Training finished", info.history))
 }
 
 </script>

--- a/peerjs-backend/sender.html
+++ b/peerjs-backend/sender.html
@@ -6,7 +6,7 @@
 </div>
 
 <div>
-<input type="text" placeholder="Receiver" id="receiver">
+<input type="text" placeholder="Receivers" id="receivers">
 <button onclick="send()">Send</button>
 </div>
 
@@ -43,24 +43,39 @@ const model_train_data = {
 }
 
 var peerjs = null
-var receiver = null
+var receivers = []
 var recv_buffer = {}
 var epoch = 0
 
 function onEpochBegin() {
-  console.log("EPOCH: ", epoch++)
+  console.log("EPOCH: ", ++epoch)
 }
 
 async function onEpochEnd() {
-  console.log("Sending weights")
   const serialized_weights = await serializeWeights(model)
+  const epoch_weights = {epoch : epoch, weights : serialized_weights}
 
-  await send_data(serialized_weights, CMD_CODES.AVG_WEIGHTS, peerjs, receiver)
-  await data_received(recv_buffer, "avg_weights")
+  for (var i in receivers) {
+    console.log("Sending weights to: ", receivers[i])
+    await send_data(epoch_weights, CMD_CODES.AVG_WEIGHTS, peerjs, receivers[i])
+  }
+
+  if (recv_buffer.avg_weights === undefined) {
+    console.log("Waiting to receive weights...")
+    await data_received(recv_buffer, "avg_weights")
+  }
+  if (recv_buffer.avg_weights[epoch] === undefined) {
+    console.log("Waiting to receive weights for this epoch...")
+    await data_received(recv_buffer.avg_weights, epoch.toString())
+  }
+  console.log("Waiting to receive all weights for this epoch...")
+  await check_array_len(recv_buffer.avg_weights[epoch], receivers.length)
     .then(() => {
       console.log("Averaging weights")
-      averageWeightsIntoModel(recv_buffer.avg_weights, model)
-      delete recv_buffer.avg_weights
+      for(i in recv_buffer.avg_weights[epoch]) {
+        averageWeightsIntoModel(recv_buffer.avg_weights[epoch][i], model)
+      }
+      // delete recv_buffer.avg_weights
     })
 }
 
@@ -75,11 +90,13 @@ function register() {
 }
 
 async function send() {
-    receiver = document.getElementById("receiver").value
+    receivers = document.getElementById("receivers").value.split(',')
     var name = makeid(10) // random string
-    await send_model(model, peerjs, receiver, name)
-    await send_data(model_compile_data, CMD_CODES.COMPILE_MODEL, peerjs, receiver)
-    await send_data(model_train_data, CMD_CODES.TRAIN_INFO, peerjs, receiver)
+    for (i in receivers) {
+      await send_model(model, peerjs, receivers[i], name)
+      await send_data(model_compile_data, CMD_CODES.COMPILE_MODEL, peerjs, receivers[i])
+      await send_data(model_train_data, CMD_CODES.TRAIN_INFO, peerjs, receivers[i])  
+    }
 }
 
 const xs = tf.data.generator(dataGenerator);

--- a/peerjs-backend/sender.html
+++ b/peerjs-backend/sender.html
@@ -20,6 +20,7 @@
 <script src="https://rawgit.com/kawanet/msgpack-lite/master/dist/msgpack.min.js"></script>
 <script src="./peer.js"></script>
 <script src="./helpers.js"></script>
+<script src="./mnist_data.js"></script>
 
 <script>
 console.log('start')
@@ -75,7 +76,8 @@ async function onEpochEnd() {
       for(i in recv_buffer.avg_weights[epoch]) {
         averageWeightsIntoModel(recv_buffer.avg_weights[epoch][i], model)
       }
-      // delete recv_buffer.avg_weights
+      // might want to delete these after using them to avoiding hogging RAM
+      // delete recv_buffer.avg_weights[epoch]
     })
 }
 
@@ -99,18 +101,28 @@ async function send() {
     }
 }
 
-const xs = tf.data.generator(dataGenerator);
-const ys = tf.data.generator(labelGenerator);
-
-const dataSet = tf.data.zip({xs, ys}).shuffle(100 /* bufferSize */).batch(32);
 
 async function train() {
+  const mnist = new MnistData()
+  await mnist.load()
+  const [x_train_2d, y_train_2d] = mnist.getTrainData()
+  const x_train_1d_ord = tf.reshape(x_train_2d, [x_train_2d.shape[0], -1])
+  const y_train_1d_ord = tf.reshape(y_train_2d, [y_train_2d.shape[0], -1])
+
+  // shuffle
+  var indices = tf.linspace(0, x_train_1d_ord.shape[0]).cast('int32')
+  tf.util.shuffle(indices)
+  const x_train_1d = x_train_1d_ord.gather(indices)
+  const y_train_1d = y_train_1d_ord.gather(indices)
+
+
   model.compile(model_compile_data)
   console.log("Training started")
-  model.fitDataset(dataSet, {
+  await model.fit(x_train_1d, y_train_1d, {
     epochs : model_train_data.epochs,
+    batchSize: 50,
     callbacks : {onEpochBegin, onEpochEnd}
-  }).then(() => console.log("Training finished"))
+  }).then((info) => console.log("Training finished", info.history))
 }
 
 

--- a/peerjs-backend/sender.html
+++ b/peerjs-backend/sender.html
@@ -52,6 +52,10 @@ function onEpochBegin() {
   console.log("EPOCH: ", ++epoch)
 }
 
+/**
+ * Sends weights to all peers, waits to receive weights from all peers
+ * and then averages peers' weights into the model.
+*/
 async function onEpochEnd() {
   const serialized_weights = await serializeWeights(model)
   const epoch_weights = {epoch : epoch, weights : serialized_weights}
@@ -76,13 +80,13 @@ async function onEpochEnd() {
       for(i in recv_buffer.avg_weights[epoch]) {
         averageWeightsIntoModel(recv_buffer.avg_weights[epoch][i], model)
       }
-      // might want to delete these after using them to avoiding hogging RAM
+      // might want to delete weights after using them to avoiding hogging memory
       // delete recv_buffer.avg_weights[epoch]
     })
 }
 
 
-
+// register peer name on PeerJS server
 function register() {
   const username = document.getElementById("username").value
 
@@ -91,6 +95,7 @@ function register() {
 
 }
 
+// send model to comma-separated peers
 async function send() {
     receivers = document.getElementById("receivers").value.split(',')
     var name = makeid(10) // random string
@@ -101,7 +106,7 @@ async function send() {
     }
 }
 
-
+// train model
 async function train() {
   const mnist = new MnistData()
   await mnist.load()
@@ -109,7 +114,7 @@ async function train() {
   const x_train_1d_ord = tf.reshape(x_train_2d, [x_train_2d.shape[0], -1])
   const y_train_1d_ord = tf.reshape(y_train_2d, [y_train_2d.shape[0], -1])
 
-  // shuffle
+  // shuffle to avoid having the same thing on all peers
   var indices = tf.linspace(0, x_train_1d_ord.shape[0]).cast('int32')
   tf.util.shuffle(indices)
   const x_train_1d = x_train_1d_ord.gather(indices)


### PR DESCRIPTION
Implements training with n peers on MNIST. With 3 peers on my laptop this is quite slow (~10 minutes for 5 epochs) and it seems like the bottleneck is not communication (peers need to sync at every epoch) but the training itself. I think at this stage we are not too concerned with speed though.

To try it out, the process is pretty much the same as in PR #21, except for the following:
- Open 1 tab for `sender.html` and as many as you like for `receiver.html`. Then register everyone with a unique username. The "Sender" is the peer that creates and communicates the model architecture.
- In the "Receivers" text box, write comma-separated names (no spaces) for all peers, except *this* peer. E.g. if you register peers a, b, c and d, then on peer b you should write "a,c,d".

At the end of the training, the metrics history is printed to the console - you should be able to see accuracy going up.