### PR TITLE
Pull-based weight exchange

### DIFF
--- a/peerjs-backend/peer.js
+++ b/peerjs-backend/peer.js
@@ -60,6 +60,14 @@ class PeerJS {
             conn.send(data)
         })
     }
+
+    /**
+     * Change data handling function
+     */
+    set_data_handler(func, ...args) {
+        this.handle_data = func
+        this.handle_data_args = args
+    }
 }
 
 /**
@@ -227,6 +235,24 @@ async function handle_data(data, buffer) {
             buffer.weight_requests.add(payload.name) // peer name
             console.log("Weight request from: ", payload.name)
 
+            break
+    }
+}
+
+/**
+ * Handle data exchange after training is finished
+ */
+async function handle_data_end(data, buffer) {
+    console.log("Received new data: ", data)
+
+    // convert the peerjs ArrayBuffer back into Uint8Array
+    payload = msgpack.decode(new Uint8Array(data.payload))
+    switch(data.cmd_code) {
+        case CMD_CODES.WEIGHT_REQUEST:
+            const receiver = payload.name
+            const epoch_weights = {epoch : buffer.epoch, weights : buffer.weights}
+            console.log("Sending weights to: ", receiver)
+            await send_data(epoch_weights, CMD_CODES.AVG_WEIGHTS, buffer.peerjs, receiver)
             break
     }
 }

--- a/peerjs-backend/peer.js
+++ b/peerjs-backend/peer.js
@@ -9,6 +9,7 @@ const CMD_CODES = {
     MODEL_INFO      : 2, // serialized model architecture
     COMPILE_MODEL   : 3, // args to model.compile, e.g. optimizer, metrics 
     AVG_WEIGHTS     : 4, // weights to average into model
+    WEIGHT_REQUEST  : 5, // ask for weights
 }
 Object.freeze(CMD_CODES) // make object immutable
 
@@ -218,6 +219,9 @@ async function handle_data(data, buffer) {
             break
         case CMD_CODES.TRAIN_INFO:
             buffer.train_info = payload
+            break
+        case CMD_CODES.WEIGHT_REQUEST:
+            buffer.weight_req_epoch = payload
             break
     }
 }

--- a/peerjs-backend/peer.js
+++ b/peerjs-backend/peer.js
@@ -164,7 +164,7 @@ function send_data(data, code, peerjs, receiver) {
         payload     : msgpack.encode(data)
     }
 
-    console.log("Sending data")
+    console.log("Sending data", data)
     console.log(send_data)
     peerjs.send(receiver, send_data)
 }
@@ -221,7 +221,12 @@ async function handle_data(data, buffer) {
             buffer.train_info = payload
             break
         case CMD_CODES.WEIGHT_REQUEST:
-            buffer.weight_req_epoch = payload
+            if (buffer.weight_requests === undefined) {
+                buffer.weight_requests = new Set([])
+            }           
+            buffer.weight_requests.add(payload.name) // peer name
+            console.log("Weight request from: ", payload.name)
+
             break
     }
 }

--- a/peerjs-backend/receiver.html
+++ b/peerjs-backend/receiver.html
@@ -25,7 +25,7 @@ console.log('start')
 
 var peerjs = null
 var model = null
-var receivers = null
+var receivers = []
 var recv_buffer = {}
 var epoch = 0
 
@@ -53,54 +53,9 @@ function onEpochBegin() {
   console.log("EPOCH: ", ++epoch)
 }
 
-/**
- * Sends weights to all peers, waits to receive weights from all peers
- * and then averages peers' weights into the model.
-*/
-async function onEpochEnd() {
-  const serialized_weights = await serializeWeights(model)
-  const epoch_weights = {epoch : epoch, weights : serialized_weights}
 
-  for (var i in receivers) {
-    console.log("Sending weights to: ", receivers[i])
-    await send_data(epoch_weights, CMD_CODES.AVG_WEIGHTS, peerjs, receivers[i])
-  }
+train(recv_buffer.compile_data, recv_buffer.train_info, onEpochBegin, onEpochEnd)
 
-  if (recv_buffer.avg_weights === undefined) {
-    console.log("Waiting to receive weights...")
-    await data_received(recv_buffer, "avg_weights")
-  }
-  if (recv_buffer.avg_weights[epoch] === undefined) {
-    console.log("Waiting to receive weights for this epoch...")
-    await data_received(recv_buffer.avg_weights, epoch.toString())
-  }
-  console.log("Waiting to receive all weights for this epoch...")
-  await check_array_len(recv_buffer.avg_weights[epoch], receivers.length)
-    .then(() => {
-      console.log("Averaging weights")
-      for(i in recv_buffer.avg_weights[epoch]) {
-        averageWeightsIntoModel(recv_buffer.avg_weights[epoch][i], model)
-      }
-      // delete recv_buffer.avg_weights
-    })
-}
-
-// train model (might want to add shuffling here for the prototype)
-async function train() {
-  const mnist = new MnistData()
-  await mnist.load()
-  const [x_train_2d, y_train_2d] = mnist.getTrainData()
-  const x_train_1d = tf.reshape(x_train_2d, [x_train_2d.shape[0], -1])
-  const y_train_1d = tf.reshape(y_train_2d, [y_train_2d.shape[0], -1])
-
-  model.compile(recv_buffer.compile_data)
-  console.log("Training started")
-  await model.fit(x_train_1d, y_train_1d, {
-    epochs : recv_buffer.train_info.epochs,
-    batchSize: 50,
-    callbacks : {onEpochBegin, onEpochEnd}
-  }).then((info) => console.log("Training finished", info.history))
-}
 
 </script>
   </body>

--- a/peerjs-backend/receiver.html
+++ b/peerjs-backend/receiver.html
@@ -61,7 +61,7 @@ function onEpochBegin() {
 
 async function onEpochEnd() {
   await onEpochEnd_common(model, epoch, receivers, recv_buffer, username, threshold)
-  // await onEpochEnd_Sync(model, epoch, receivers, recv_buffer)
+  // await onEpochEnd_Sync(model, epoch, receivers, recv_buffer) // synchronized communication scheme
 }
 
 async function train(){

--- a/peerjs-backend/receiver.html
+++ b/peerjs-backend/receiver.html
@@ -28,11 +28,17 @@ var model = null
 var receivers = []
 var recv_buffer = {}
 var epoch = 0
+username = null
+
+
+threshold = null // minimum number of received weights to continue training
 
 // register peer name on PeerJS server
 async function register() {
-  const username = document.getElementById("username").value
+  username = document.getElementById("username").value
   receivers = document.getElementById("receivers").value.split(',')
+  threshold = Math.min(Math.ceil(receivers.length / 2), 5)
+  console.log("Threshold: ", threshold)
 
   peer = new Peer(username, {host: 'localhost', port: 9000, path: '/myapp'})
   peerjs = new PeerJS(peer, handle_data, recv_buffer)
@@ -53,8 +59,14 @@ function onEpochBegin() {
   console.log("EPOCH: ", ++epoch)
 }
 
+async function onEpochEnd() {
+  await onEpochEnd_common(model, epoch, receivers, recv_buffer, username, threshold)
+  // await onEpochEnd_Sync(model, epoch, receivers, recv_buffer)
+}
 
-train(recv_buffer.compile_data, recv_buffer.train_info, onEpochBegin, onEpochEnd)
+async function train(){
+  train_common(model, recv_buffer.compile_data, recv_buffer.train_info, onEpochBegin, onEpochEnd)
+}
 
 
 </script>

--- a/peerjs-backend/sender.html
+++ b/peerjs-backend/sender.html
@@ -52,39 +52,6 @@ function onEpochBegin() {
   console.log("EPOCH: ", ++epoch)
 }
 
-/**
- * Sends weights to all peers, waits to receive weights from all peers
- * and then averages peers' weights into the model.
-*/
-async function onEpochEnd() {
-  const serialized_weights = await serializeWeights(model)
-  const epoch_weights = {epoch : epoch, weights : serialized_weights}
-
-  for (var i in receivers) {
-    console.log("Sending weights to: ", receivers[i])
-    await send_data(epoch_weights, CMD_CODES.AVG_WEIGHTS, peerjs, receivers[i])
-  }
-
-  if (recv_buffer.avg_weights === undefined) {
-    console.log("Waiting to receive weights...")
-    await data_received(recv_buffer, "avg_weights")
-  }
-  if (recv_buffer.avg_weights[epoch] === undefined) {
-    console.log("Waiting to receive weights for this epoch...")
-    await data_received(recv_buffer.avg_weights, epoch.toString())
-  }
-  console.log("Waiting to receive all weights for this epoch...")
-  await check_array_len(recv_buffer.avg_weights[epoch], receivers.length)
-    .then(() => {
-      console.log("Averaging weights")
-      for(i in recv_buffer.avg_weights[epoch]) {
-        averageWeightsIntoModel(recv_buffer.avg_weights[epoch][i], model)
-      }
-      // might want to delete weights after using them to avoiding hogging memory
-      // delete recv_buffer.avg_weights[epoch]
-    })
-}
-
 
 // register peer name on PeerJS server
 function register() {
@@ -106,29 +73,7 @@ async function send() {
     }
 }
 
-// train model
-async function train() {
-  const mnist = new MnistData()
-  await mnist.load()
-  const [x_train_2d, y_train_2d] = mnist.getTrainData()
-  const x_train_1d_ord = tf.reshape(x_train_2d, [x_train_2d.shape[0], -1])
-  const y_train_1d_ord = tf.reshape(y_train_2d, [y_train_2d.shape[0], -1])
-
-  // shuffle to avoid having the same thing on all peers
-  var indices = tf.linspace(0, x_train_1d_ord.shape[0]).cast('int32')
-  tf.util.shuffle(indices)
-  const x_train_1d = x_train_1d_ord.gather(indices)
-  const y_train_1d = y_train_1d_ord.gather(indices)
-
-
-  model.compile(model_compile_data)
-  console.log("Training started")
-  await model.fit(x_train_1d, y_train_1d, {
-    epochs : model_train_data.epochs,
-    batchSize: 50,
-    callbacks : {onEpochBegin, onEpochEnd}
-  }).then((info) => console.log("Training finished", info.history))
-}
+train(model_compile_data, model_train_data, onEpochBegin, onEpochEnd)
 
 
 </script>

--- a/peerjs-backend/sender.html
+++ b/peerjs-backend/sender.html
@@ -45,7 +45,7 @@ const model_train_data = {
 
 var peerjs = null
 var receivers = []
-var recv_buffer = {}
+var recv_buffer = { train_info : model_train_data } // to get number of epochs in onEpochEnd
 var epoch = 0
 username = null
 

--- a/peerjs-backend/sender.html
+++ b/peerjs-backend/sender.html
@@ -57,7 +57,7 @@ function onEpochBegin() {
 
 async function onEpochEnd() {
   await onEpochEnd_common(model, epoch, receivers, recv_buffer, username, threshold)
-  // await onEpochEnd_Sync(model, epoch, receivers, recv_buffer)
+  // await onEpochEnd_Sync(model, epoch, receivers, recv_buffer) // synchronized communication scheme
 }
 
 // register peer name on PeerJS server

--- a/peerjs-backend/sender.html
+++ b/peerjs-backend/sender.html
@@ -47,24 +47,34 @@ var peerjs = null
 var receivers = []
 var recv_buffer = {}
 var epoch = 0
+username = null
+
+threshold = null // minimum number of received weights to continue training
 
 function onEpochBegin() {
   console.log("EPOCH: ", ++epoch)
 }
 
+async function onEpochEnd() {
+  await onEpochEnd_common(model, epoch, receivers, recv_buffer, username, threshold)
+  // await onEpochEnd_Sync(model, epoch, receivers, recv_buffer)
+}
 
 // register peer name on PeerJS server
 function register() {
-  const username = document.getElementById("username").value
+  username = document.getElementById("username").value
 
   peer = new Peer(username, {host: 'localhost', port: 9000, path: '/myapp'})
   peerjs = new PeerJS(peer, handle_data, recv_buffer)
+
+  receivers = document.getElementById("receivers").value.split(',')
+  threshold = Math.min(Math.ceil(receivers.length / 2), 5)  
+  console.log("Threshold: ", threshold)
 
 }
 
 // send model to comma-separated peers
 async function send() {
-    receivers = document.getElementById("receivers").value.split(',')
     var name = makeid(10) // random string
     for (i in receivers) {
       await send_model(model, peerjs, receivers[i], name)
@@ -73,7 +83,9 @@ async function send() {
     }
 }
 
-train(model_compile_data, model_train_data, onEpochBegin, onEpochEnd)
+async function train(){
+  train_common(model, model_compile_data, model_train_data, onEpochBegin, onEpochEnd)
+}
 
 
 </script>


### PR DESCRIPTION
Introduces support for pull-based weight exchange (by using `onEpochEnd_common`) to #22. The scheme is as follows:
1. Each peer starts training.
2. At the end of each epoch, each peer send weight requests to all other peers and replies to any received weight requests.
3. Once the training is finished, any weight requests are answered with the weights of the last epoch.
4. To avoid deadlocks, there is a timeout on waiting for replies to weight requests.

The deadlock in point 4 could happen without a timeout if all peers start at about the same time: in the first epoch, they all send requests to each other and wait for answers. If the timing is right, they can all get stuck waiting for each other.