### PR TITLE
Fix gpu memory leak and lost WebGL context issue

### DIFF
--- a/mobile-browser-based-version/src/task_definition/lus_covid.js
+++ b/mobile-browser-based-version/src/task_definition/lus_covid.js
@@ -97,7 +97,9 @@ export class LusCovidTask {
 
             const processedImg = batched.toFloat().div(127).sub(1).expandDims(0);
 
-            return net.predict(processedImg)
+            const prediction = net.predict(processedImg)
+
+            return prediction
           });
 
         tf.dispose(tensor)

--- a/mobile-browser-based-version/src/task_definition/lus_covid.js
+++ b/mobile-browser-based-version/src/task_definition/lus_covid.js
@@ -91,13 +91,17 @@ export class LusCovidTask {
 
     async imagePreprocessing(src){
         const tensor = await this.loadLocalImage(src)
+
+        const representation = tf.tidy(() => {
+            const batched = tensor.reshape([this.trainingInformation.IMAGE_H, this.trainingInformation.IMAGE_W, 3])
+
+            const processedImg = batched.toFloat().div(127).sub(1).expandDims(0);
+
+            return net.predict(processedImg)
+          });
+
+        tf.dispose(tensor)
         
-        const batched = tensor.reshape([this.trainingInformation.IMAGE_H, this.trainingInformation.IMAGE_W, 3])
-
-        const processedImg = batched.toFloat().div(127).sub(1).expandDims(0);
-
-        let representation = net.predict(processedImg)
-
         return representation
     }
 
@@ -152,8 +156,8 @@ export class LusCovidTask {
             }else{
                 dictLabels[id] = labelsPerImage[i]
             }
-
-            res.push(await this.imagePreprocessing(imageUri[i]))
+            let result = await this.imagePreprocessing(imageUri[i])
+            res.push(result)
 
             dictImages[id] = res
         }


### PR DESCRIPTION
Resolves #62 

The issue was that intermediate value tensors from image preprocessing were unnecessarily kept in memory. This is fixed now with the use of `tf.tidy`