### PR TITLE
Add deployment scripts

### DIFF
--- a/mobile-browser-based-version/deploy.sh
+++ b/mobile-browser-based-version/deploy.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+# abort on errors
+set -e
+
+# build
+npm run build
+
+# navigate into the build output directory
+cd dist
+
+# initialize repo
+git init
+git add -A
+git commit -m 'deploy'
+
+# push to DeAI
+git push -f https://github.com/epfml/DeAI.git master:gh-pages
+
+cd -

--- a/mobile-browser-based-version/vue.config.js
+++ b/mobile-browser-based-version/vue.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    publicPath: process.env.NODE_ENV === 'production'
+      ? '/DeAI/'
+      : '/'
+  }


### PR DESCRIPTION
This PR adds the config and script used to deploy to Github pages. To deploy your changes to Github Pages, run the script `deploy.sh` from inside the `mobile-browser-based-version` folder. It will ask you for the username and password in order to push to Github. 

The deployed app is available on: https://epfml.github.io/DeAI/

I will try to automate the deployment using Github Actions whenever there is a change to `master`. 