### PR TITLE
Resolve 404 error in deployed version

### DIFF
--- a/mobile-browser-based-version/src/router/index.js
+++ b/mobile-browser-based-version/src/router/index.js
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHashHistory } from 'vue-router'
 
 // Some page components 
 import TaskList from "../components/TaskList"
@@ -87,7 +87,7 @@ for (let index = 0; index < ALL_TASKS.length; index++) {
 console.log(routes)
 
 const router = createRouter({
-  history: createWebHistory(process.env.BASE_URL),
+  history: createWebHashHistory(process.env.BASE_URL),
   routes
 })
 console.log(router.getRoutes())


### PR DESCRIPTION
This is meant to fix the issue of seeing a 404 page when refreshing a page in the deployed version. 

The 404 issue is explained [here](https://next.router.vuejs.org/guide/essentials/history-mode.html#html5-mode).

The other way to fix this on Github Pages is to make the `404.html` file a duplicate of `index.html`. However, that solution seemed hackier to me, and we will lose the default 404 behavior.  