### PR TITLE
Fix HTTPS error in Github Pages deployment

### DIFF
--- a/mobile-browser-based-version/server/README.md
+++ b/mobile-browser-based-version/server/README.md
@@ -1,4 +1,4 @@
-## DeAI Server
+## DeAI Helper Server
 Centralized helper server for DeAI clients, running as an ExpressJS app. The server requires [Node](https://nodejs.org/en/), [Express](https://expressjs.com/), [PeerServer](https://github.com/peers/peerjs-server) and [Tensorflow](https://www.tensorflow.org/js). All library requirements are included in the ```package.json``` file.
 ### Components
 #### PeerJS server
@@ -16,7 +16,7 @@ The training tasks given to DeAI clients are centralized on this server. Their d
 
 Tasks are stored in ```tasks.json```. The models are declared in ```models.js```.
 
-### Running the server
+### Running the helper server
 
 From this folder, you can run the server on localhost:8080 with the following command:
 ```
@@ -25,7 +25,7 @@ npm start
 
 ### Running in Google App Engine
 
-Google App Engine (GAE) creates an HTTPS certificate automatically, making this the easiest way to deploy the server in the Google Cloud Platform.
+Google App Engine (GAE) creates an HTTPS certificate automatically, making this the easiest way to deploy the helper server in the Google Cloud Platform.
 
 To change the GAE app configuration, you can modify the file `app.yaml`. Do not modify the flex enviroment because it is required for WebSocket support, which is required for PeerJS. 
 

--- a/mobile-browser-based-version/server/README.md
+++ b/mobile-browser-based-version/server/README.md
@@ -18,8 +18,19 @@ Tasks are stored in ```tasks.json```. The models are declared in ```models.js```
 
 ### Running the server
 
-From this folder, you can run the server on localhost:port with the following command:
+From this folder, you can run the server on localhost:8080 with the following command:
 ```
-npm start port tasks_file
+npm start
 ```
-specifying the desired port and tasks JSON file.
+
+### Running in Google App Engine
+
+Google App Engine (GAE) creates an HTTPS certificate automatically, making this the easiest way to deploy the server in the Google Cloud Platform.
+
+To change the GAE app configuration, you can modify the file `app.yaml`. Do not modify the flex enviroment because it is required for WebSocket support, which is required for PeerJS. 
+
+To deploy the app on GAE, you can run the following command, replacing PROJECT-ID with the your project ID:
+
+```
+gcloud app deploy --project=PROJECT-ID --promote --quiet app.yaml
+```

--- a/mobile-browser-based-version/server/app.yaml
+++ b/mobile-browser-based-version/server/app.yaml
@@ -1,0 +1,12 @@
+runtime: nodejs
+
+# Flex environment required for WebSocket support, which is required for PeerJS.
+env: flex
+
+# Limit resources to one instance, one CPU, very little memory or disk.
+manual_scaling:
+  instances: 1
+resources:
+  cpu: 1
+  memory_gb: 0.5
+  disk_size_gb: 0.5

--- a/mobile-browser-based-version/server/run_server.js
+++ b/mobile-browser-based-version/server/run_server.js
@@ -7,15 +7,15 @@ const { models }            = require('./models.js');
 const cors                  = require('cors');
 
 const app = express();
+app.enable('trust proxy');
 app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({extended: false}));
 
 const topology = new topologies.BinaryTree()
 
-const myArgs = process.argv.slice(2);
-
-const server = app.listen(myArgs[0]);
+// GAE requires the app to listen to 8080
+const server = app.listen(8080);
 const peerServer = ExpressPeerServer(server, {
     path: '/',
     allow_discovery: true,
@@ -65,7 +65,7 @@ peerServer.on('disconnect', (client) => {
     sendNewNeighbours(affectedPeers)
 });
 
-const tasks = JSON.parse(fs.readFileSync(myArgs[1]));
+const tasks = JSON.parse(fs.readFileSync('tasks.json'));
 
 const tasksRouter = express.Router();
 tasksRouter.get('/', (req, res) => res.send(tasks));
@@ -77,3 +77,4 @@ app.get('/', (req, res) => res.send('DeAI Server'));
 app.use('/deai', peerServer);
 app.get('/neighbours/:id', eventsHandler);
 app.use('/tasks', tasksRouter);
+module.exports = app;

--- a/mobile-browser-based-version/src/helpers/communication_script/communication_manager.js
+++ b/mobile-browser-based-version/src/helpers/communication_script/communication_manager.js
@@ -59,7 +59,7 @@ export class CommunicationManager {
 
         this.peer = new Peer(this.peerjsId,
             {
-                host: '35.242.193.186', port: 9000, path: '/deai',
+                host: 'deai-313515.ew.r.appspot.com', path: '/deai', secure: true,
                 config: {
                     'iceServers': [
                         { url: 'stun:stun.l.google.com:19302' },


### PR DESCRIPTION
Currently, the deployed app on Github Pages can't connect to the server because Github Pages uses SSL, and we do not have a valid SSL certificate on the current Peer.js server. 

However, Google App Engine (GAE) automatically creates an HTTPS certificate if we deploy the app there. 

This PR introduces the necessary files and README instructions to deploy the app on GAE. 

I already deployed the app on GAE and pointed our frontend to the new host. It is available on this [link](https://deai-313515.ew.r.appspot.com).

After merging, this should enable the frontend to connect to the PeerJS server when deployed on Github Pages. 