### PR TITLE
update image type information

### DIFF
--- a/mobile-browser-based-version/src/task_definition/lus_covid.js
+++ b/mobile-browser-based-version/src/task_definition/lus_covid.js
@@ -320,7 +320,7 @@ export const displayInformation = {
     // {String} trade-offs of the model 
     tradeoffs: "We are using a simpler version of DeepChest in order to be able to run it on the browser.",
     // {String} information about expected data 
-    dataFormatInformation: "This model takes as input an image dataset. It consists on a set of lung ultrasound images per patient with its corresponding label of covid positive or negative. Moreover, to identify the images per patient you have to follow the follwing naming pattern: \"patientId_*.png\"",
+    dataFormatInformation: "This model uses lung ultrasound images with its corresponding label of covid positive or negative. Moreover, to identify the images per patient you have to follow the following naming pattern: \"patientId_*\"",
     // {String} description of the datapoint given as example
     dataExampleText: "Below you can find an example of an expected lung image for patient 2 named: 2_QAID_1.masked.reshaped.squared.224.png",
     // {String} local url to an image data example
@@ -353,7 +353,6 @@ export const trainingInformation = {
         epochs: 10,
     },
     threshold: 2,
-
     IMAGE_H : 224,
     IMAGE_W : 224,
     LABEL_LIST : ["COVID-Positive", "COVID-Negative"],

--- a/mobile-browser-based-version/src/task_definition/mnist.js
+++ b/mobile-browser-based-version/src/task_definition/mnist.js
@@ -224,7 +224,7 @@ export const displayInformation = {
     tradeoffs: "We are using a simple model, first a 2d convolutional layer > max pooling > 2d convolutional layer > max pooling > convolutional layer > 2 dense layers.",
     // {String} information about expected data 
     dataFormatInformation:
-        "This model takes as input an image dataset. You can upload each digit image of your dataset in the box corresponding to its label. The size of the image will be reduced to 28x28. Finally, the image should be in grey scale.",
+        "This model is trained on images corresponding to digits 0 to 9. You can upload each digit image of your dataset in the box corresponding to its label. The model taskes images of size 28x28 as input.",
     // {String} description of the datapoint given as example
     dataExampleText: "Below you can find an example of an expected image representing the digit 9.",
     // {String} local url to an image data example


### PR DESCRIPTION
Update regarding #101 
Minor changes in text or description of models.

Checked for different images as input: jpg, png with transparency, svg. All of those were accepted. 
Both models are using 3-channel images as input.